### PR TITLE
Use "music" status type

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -29,10 +29,10 @@ function u(r) {
     "tags": [
       [
         "d",
-        "general"
+        "music"
       ]
     ],
-    "content": title ? `🎵${title} - ${artist}` : ""
+    "content": title ? `${title} - ${artist}` : ""
   };
 
   event.id = getEventHash(event);


### PR DESCRIPTION
We should use `music` status type (the d-tag value of `kind: 30315` events) for the purpose of sharing music via user statuses.

cf. [NIP-38](https://github.com/nostr-protocol/nips/blob/master/38.md)

Further more, AFAIK major Nostr clients that support NIP-38 render `music` user status with the musical symbol (♫), so we can omit it from the `content`.